### PR TITLE
Fix clipboard paste in terminal sessions

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -64,7 +64,25 @@ function createWindow() {
   // Show window as soon as the renderer is ready — avoids white flash
   mainWindow.once('ready-to-show', () => mainWindow.show());
 
-  Menu.setApplicationMenu(null);
+  // Preserve a minimal Edit menu so native clipboard accelerators (Ctrl+V paste,
+  // Ctrl+C copy, etc.) keep working inside xterm.js terminals. Setting the menu
+  // to null removes all default accelerators and silently breaks paste.
+  Menu.setApplicationMenu(
+    Menu.buildFromTemplate([
+      {
+        label: 'Edit',
+        submenu: [
+          { role: 'undo' },
+          { role: 'redo' },
+          { type: 'separator' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'selectAll' },
+        ],
+      },
+    ])
+  );
   sessionManager.setWindow(mainWindow);
 
   if (MAIN_WINDOW_VITE_DEV_SERVER_URL) {


### PR DESCRIPTION
## Summary
- `Menu.setApplicationMenu(null)` removes all native Electron accelerators, including Ctrl+V, which prevents the browser `paste` event from reaching xterm.js terminals
- Replaced with a minimal Edit menu that preserves clipboard accelerators (cut, copy, paste, undo, redo, select all)
- The menu is visually hidden by the existing `titleBarStyle: 'hidden'` configuration, so there's no UI change

## Test plan
- [ ] Open a terminal session (Claude, Codex, or raw shell)
- [ ] Copy text to clipboard and press Ctrl+V — text should now paste into the terminal
- [ ] Verify Ctrl+C (copy) and Ctrl+X (cut) also work when selecting terminal text
- [ ] Confirm no visible menu bar appears (hidden titlebar still in effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)