### PR TITLE
Add Ctrl+/- terminal font zoom

### DIFF
--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -43,9 +43,15 @@ function buildTerminalTheme() {
   };
 }
 
+const DEFAULT_FONT_SIZE = 14;
+const MIN_FONT_SIZE = 8;
+const MAX_FONT_SIZE = 32;
+let terminalFontSize = DEFAULT_FONT_SIZE;
+
 export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>) {
   const selectedSessionId = useAppStore((s) => s.selectedSessionId);
   const termRef = useRef<Terminal | null>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
 
   useEffect(() => {
     if (!containerRef.current || !selectedSessionId) return;
@@ -53,13 +59,14 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     // Create terminal
     const term = new Terminal({
       theme: buildTerminalTheme(),
-      fontSize: 14,
+      fontSize: terminalFontSize,
       fontFamily: 'Cascadia Code, Consolas, monospace',
       cursorBlink: true,
       convertEol: true,
     });
 
     const fitAddon = new FitAddon();
+    fitAddonRef.current = fitAddon;
     term.loadAddon(fitAddon);
     term.open(containerRef.current);
 
@@ -80,6 +87,32 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
     });
 
     termRef.current = term;
+
+    // Ctrl+Plus / Ctrl+Minus / Ctrl+0 to zoom terminal font
+    const sessionId_ = selectedSessionId;
+    term.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      if (!e.ctrlKey || e.type !== 'keydown') return true;
+      let newSize = terminalFontSize;
+      if (e.key === '=' || e.key === '+') {
+        newSize = Math.min(terminalFontSize + 2, MAX_FONT_SIZE);
+      } else if (e.key === '-') {
+        newSize = Math.max(terminalFontSize - 2, MIN_FONT_SIZE);
+      } else if (e.key === '0') {
+        newSize = DEFAULT_FONT_SIZE;
+      } else {
+        return true;
+      }
+      if (newSize !== terminalFontSize) {
+        terminalFontSize = newSize;
+        term.options.fontSize = newSize;
+        try {
+          fitAddon.fit();
+          window.agentPlex.resizeSession(sessionId_, term.cols, term.rows);
+        } catch { /* ignore */ }
+      }
+      e.preventDefault();
+      return false;
+    });
 
     // Update terminal theme when data-theme attribute changes
     const observer = new MutationObserver(() => {
@@ -128,6 +161,7 @@ export function useTerminal(containerRef: React.RefObject<HTMLDivElement | null>
       cleanup();
       term.dispose();
       termRef.current = null;
+      fitAddonRef.current = null;
     };
   }, [selectedSessionId]); // intentionally only depend on session change
 }


### PR DESCRIPTION
## Summary
- Adds keyboard shortcuts to zoom terminal text: **Ctrl+Plus** (increase), **Ctrl+Minus** (decrease), **Ctrl+0** (reset to default)
- Font size range: 8–32px, step size 2px, default 14px
- Persists across session switches; PTY cols/rows re-synced after each change via `fitAddon.fit()` + `resizeSession`

## Test plan
- [ ] Open a terminal session
- [ ] Press Ctrl+= (or Ctrl+Shift+=) — font should grow
- [ ] Press Ctrl+- — font should shrink
- [ ] Press Ctrl+0 — font should reset to 14px
- [ ] Switch to another session and back — font size should persist
- [ ] Verify terminal content reflows correctly after zoom

🤖 Generated with [Claude Code](https://claude.com/claude-code)